### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,11 +15,13 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.0, 7.4]
-        laravel: [8.*]
+        laravel: [8.*,9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
+          - laravel: 9.*
+            testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,9 @@ jobs:
         php: [8.0, 7.4]
         laravel: [8.*,9.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - laravel: 9.*
+            php: 7.4
         include:
           - laravel: 8.*
             testbench: 6.*

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
         "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0.1",
-        "illuminate/collections": "^8.0",
-        "illuminate/http": "^8.0",
-        "illuminate/support": "^8.0"
+        "illuminate/collections": "^8.0 || ^9.0",
+        "illuminate/http": "^8.0 || ^9.0",
+        "illuminate/support": "^8.0 || ^9.0"
     },
     "require-dev": {
         "gajus/dindent": "^2.0",
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^6.0 || ^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "config": {


### PR DESCRIPTION
- Allow Laravel 9 in composer.json
- Allow testbench 7 in composer.json
- Add the config for Laravel 9 with testbench in run-tests GitHub action.